### PR TITLE
Add StyleCop.Analyzers to the project

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,52 @@
+﻿[*.cs]
+
+# SA0001: XML comment analysis disabled
+dotnet_diagnostic.SA0001.severity = none
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = none
+
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none
+
+# SA1308: Variable names should not be prefixed
+dotnet_diagnostic.SA1308.severity = none
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# SA1310: Field names should not contain underscore
+dotnet_diagnostic.SA1310.severity = none
+
+# SA1515: Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = none
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = none
+
+# SA1611: Element parameters should be documented
+dotnet_diagnostic.SA1611.severity = none
+
+# SA1615: Element return value should be documented
+dotnet_diagnostic.SA1615.severity = none
+
+# SA1618: Generic type parameters should be documented
+dotnet_diagnostic.SA1618.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SX1101: Do not prefix local calls with 'this.'
+dotnet_diagnostic.SX1101.severity = warning
+
+# SX1309: Field names should begin with underscore
+dotnet_diagnostic.SX1309.severity = warning

--- a/src/NpgsqlAnalyzers.Tests/NpgsqlAnalyzers.Tests.csproj
+++ b/src/NpgsqlAnalyzers.Tests/NpgsqlAnalyzers.Tests.csproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +19,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="ThrowawayDb.Postgres" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
@@ -1,7 +1,7 @@
+using System;
 using Microsoft.CodeAnalysis;
 using NpgsqlAnalyzers.Tests.Utils;
 using NUnit.Framework;
-using System;
 using ThrowawayDb.Postgres;
 
 namespace NpgsqlAnalyzers.Tests
@@ -131,6 +131,7 @@ namespace Testing
                 {
                     _database.Dispose();
                 }
+
                 _isDisposed = true;
             }
         }

--- a/src/NpgsqlAnalyzers.Tests/Utils/DiagnosticResult.cs
+++ b/src/NpgsqlAnalyzers.Tests/Utils/DiagnosticResult.cs
@@ -14,6 +14,7 @@ namespace NpgsqlAnalyzers.Tests.Utils
                 {
                     _locations = new DiagnosticResultLocation[] { };
                 }
+
                 return _locations;
             }
             set

--- a/src/NpgsqlAnalyzers.Tests/Utils/Diagnostics.cs
+++ b/src/NpgsqlAnalyzers.Tests/Utils/Diagnostics.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-using Npgsql;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Npgsql;
+using NUnit.Framework;
 
 namespace NpgsqlAnalyzers.Tests.Utils
 {
@@ -52,7 +52,7 @@ namespace NpgsqlAnalyzers.Tests.Utils
             DiagnosticAnalyzer analyzer,
             params DiagnosticResult[] expected)
         {
-            var diagnostics = GetDiagnostics(new [] { source }, analyzer);
+            var diagnostics = GetDiagnostics(new string[] { source }, analyzer);
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
         }
 
@@ -115,7 +115,7 @@ namespace NpgsqlAnalyzers.Tests.Utils
                 Assert.Fail(
                     CreateErrorMessage(
                         header: "Mismatch between number of diagnostics returned.",
-                        expected:  $"Expected to find '{expectedCount}' diagnostics.",
+                        expected: $"Expected to find '{expectedCount}' diagnostics.",
                         actual: $"Found '{actualCount}' diagnostics.",
                         diagnostic: diagnosticsOutput));
             }
@@ -325,7 +325,8 @@ namespace NpgsqlAnalyzers.Tests.Utils
                         string resultMethodName = "GetCSharpResultAt";
                         var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
-                        builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
+                        builder.AppendFormat(
+                            "{0}({1}, {2}, {3}.{4})",
                             resultMethodName,
                             linePosition.Line + 1,
                             linePosition.Character + 1,

--- a/src/NpgsqlAnalyzers.sln
+++ b/src/NpgsqlAnalyzers.sln
@@ -5,7 +5,13 @@ VisualStudioVersion = 16.0.30001.183
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NpgsqlAnalyzers", "NpgsqlAnalyzers\NpgsqlAnalyzers.csproj", "{D7FF940C-6293-4C64-B873-DBFCE8EBC725}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NpgsqlAnalyzers.Tests", "NpgsqlAnalyzers.Tests\NpgsqlAnalyzers.Tests.csproj", "{1B90C664-8548-4F80-8466-57AA2DC32F95}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NpgsqlAnalyzers.Tests", "NpgsqlAnalyzers.Tests\NpgsqlAnalyzers.Tests.csproj", "{1B90C664-8548-4F80-8466-57AA2DC32F95}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E14A652F-B079-467D-A3A0-4816B8385D25}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		build.props = build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NpgsqlAnalyzers.sln
+++ b/src/NpgsqlAnalyzers.sln
@@ -10,7 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E14A652F-B079-467D-A3A0-4816B8385D25}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		build.props = build.props
 	EndProjectSection
 EndProject
 Global

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzers.csproj
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzers.csproj
@@ -5,6 +5,11 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,6 +28,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
     <PackageReference Include="Npgsql" Version="4.1.3" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzers.csproj
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzers.csproj
@@ -5,7 +5,6 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/build.props
+++ b/src/build.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(Language)' == 'C#'">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This update adds the [StyleCop.Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) static code analyzers to the project and fixes code to adhere.

- Add .editorconfig for overriding analyzers rules
- Closes #5 