### PR TITLE
Report more diagnostics

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,7 @@
+# NpgsqlAnalyzers rules
+
+|  Id  | Name | Severity | Description |
+| ---- | :--- | :------- | :---------- |
+| `PSCA1000` | Bad SQL statement | Warning | Reports SQL errors which are not explicitly handled by the analyzer. |
+| `PSCA1001` | Undefined table | Warning | A table referenced in the SQL statement does not exist. Provides the name of the table. |
+| `PSCA1002` | Undefined column | Warning | A column referenced in the SQL statement does not exist. Provides the name of the column. |

--- a/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
@@ -1,0 +1,86 @@
+using System;
+using NpgsqlAnalyzers.Tests.Utils;
+using NUnit.Framework;
+using ThrowawayDb.Postgres;
+
+namespace NpgsqlAnalyzers.Tests
+{
+    [TestFixture]
+    public class RegressionTests : IDisposable
+    {
+        private static readonly ThrowawayDatabase _database = Database.CreateDatabase();
+        private bool _isDisposed;
+
+        [Test]
+        public void AssertGoodFullDatabaseQueryDoesntFail()
+        {
+            string source = @"
+using Npgsql;
+
+namespace Testing
+{
+    public class TestClass
+    {
+        public void QueryInConstructor()
+        {
+            using var command = new NpgsqlCommand(
+                @""
+                    SELECT users.id, users.username, users.is_admin, users.created_at, posts.id, posts.title, posts.body, posts.created_at, user_posts.user_id, user_posts.post_id
+                    FROM users
+                    JOIN user_posts ON user_posts.user_id = users.id
+                    JOIN posts ON posts.id = user_posts.post_id;
+                "");
+        }
+
+        public void QueryAsVariable()
+        {
+            string query = @""
+                SELECT users.id, users.username, users.is_admin, users.created_at, posts.id, posts.title, posts.body, posts.created_at, user_posts.user_id, user_posts.post_id
+                FROM users
+                JOIN user_posts ON user_posts.user_id = users.id
+                JOIN posts ON posts.id = user_posts.post_id;
+            "";
+            using var command = new NpgsqlCommand(query);
+        }
+
+        public void QueryAsReDeclaredVariable()
+        {
+            string query = ""invalid query syntax"";
+
+            query = @""
+                SELECT users.id, users.username, users.is_admin, users.created_at, posts.id, posts.title, posts.body, posts.created_at, user_posts.user_id, user_posts.post_id
+                FROM users
+                JOIN user_posts ON user_posts.user_id = users.id
+                JOIN posts ON posts.id = user_posts.post_id;
+            "";
+            using var command = new NpgsqlCommand(query);
+        }
+    }
+}
+            ";
+
+            Diagnostics.AnalyzeSourceCode(
+                source,
+                new NpgsqlAnalyzer(_database.ConnectionString));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!_isDisposed)
+            {
+                if (isDisposing)
+                {
+                    _database.Dispose();
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
@@ -1,16 +1,11 @@
-using System;
 using NpgsqlAnalyzers.Tests.Utils;
 using NUnit.Framework;
-using ThrowawayDb.Postgres;
 
 namespace NpgsqlAnalyzers.Tests
 {
     [TestFixture]
-    public class RegressionTests : IDisposable
+    public class RegressionTests
     {
-        private static readonly ThrowawayDatabase _database = Database.CreateDatabase();
-        private bool _isDisposed;
-
         [Test]
         public void AssertGoodFullDatabaseQueryDoesntFail()
         {
@@ -59,28 +54,10 @@ namespace Testing
 }
             ";
 
+            using var database = Database.CreateDatabase();
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString));
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (!_isDisposed)
-            {
-                if (isDisposing)
-                {
-                    _database.Dispose();
-                }
-
-                _isDisposed = true;
-            }
+                new NpgsqlAnalyzer(database.ConnectionString));
         }
     }
 }

--- a/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
@@ -13,7 +13,7 @@ namespace NpgsqlAnalyzers.Tests
         private bool _isDisposed;
 
         [Test]
-        public void AssertNonExistentQueryDetectedInConstructor()
+        public void PSCA1001_DetectedInConstructor()
         {
             const string TableName = "non_existent_table";
             string source = @$"
@@ -47,7 +47,7 @@ namespace Testing
         }
 
         [Test]
-        public void AssertNonExistentTableDetectedInDeclaration()
+        public void PSCA1001_DetectedInVariableDeclaration()
         {
             const string TableName = "bad_table";
             string source = @$"
@@ -81,7 +81,7 @@ namespace Testing
         }
 
         [Test]
-        public void AssertNonExistentTableDetectedInReDeclaration()
+        public void PSCA1001_DetectedInVariableReDeclaration()
         {
             const string TableName = "bad_table";
             string source = @$"

--- a/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
@@ -36,7 +36,7 @@ namespace Testing
                 new NpgsqlAnalyzer(_database.ConnectionString),
                 new DiagnosticResult
                 {
-                    Id = "PSCA1000",
+                    Id = "PSCA1001",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new DiagnosticResultLocation[]
                     {
@@ -70,7 +70,7 @@ namespace Testing
                 new NpgsqlAnalyzer(_database.ConnectionString),
                 new DiagnosticResult
                 {
-                    Id = "PSCA1000",
+                    Id = "PSCA1001",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new DiagnosticResultLocation[]
                     {
@@ -107,7 +107,7 @@ namespace Testing
                 new NpgsqlAnalyzer(_database.ConnectionString),
                 new DiagnosticResult
                 {
-                    Id = "PSCA1000",
+                    Id = "PSCA1001",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new DiagnosticResultLocation[]
                     {

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -183,9 +183,9 @@ namespace NpgsqlAnalyzers
                     case PostgresErrorCodes.UndefinedTable:
                         string table = Regex.Match(ex.Statement.SQL.Substring(ex.Position - 1), @"\w+").Value;
                         context.ReportDiagnostic(Diagnostic.Create(
-                            descriptor: Rules.BadSqlStatement,
+                            descriptor: Rules.UndefinedTable,
                             location: sourceLocation,
-                            $"Table '{table}' does not exist."));
+                            messageArgs: table));
                         break;
 
                     default:

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -29,7 +29,9 @@ namespace NpgsqlAnalyzers
         }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
-            Rules.BadSqlStatement);
+            Rules.BadSqlStatement,
+            Rules.UndefinedTable,
+            Rules.UndefinedColumn);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -186,6 +188,14 @@ namespace NpgsqlAnalyzers
                             descriptor: Rules.UndefinedTable,
                             location: sourceLocation,
                             messageArgs: table));
+                        break;
+
+                    case PostgresErrorCodes.UndefinedColumn:
+                        string column = Regex.Match(ex.Statement.SQL.Substring(ex.Position - 1), @"\w+").Value;
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            descriptor: Rules.UndefinedColumn,
+                            location: sourceLocation,
+                            messageArgs: column));
                         break;
 
                     default:

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -189,6 +189,10 @@ namespace NpgsqlAnalyzers
                         break;
 
                     default:
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            descriptor: Rules.BadSqlStatement,
+                            location: sourceLocation,
+                            ex.Message));
                         break;
                 }
             }

--- a/src/NpgsqlAnalyzers/Rules.cs
+++ b/src/NpgsqlAnalyzers/Rules.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace NpgsqlAnalyzers
 {
@@ -16,6 +17,14 @@ namespace NpgsqlAnalyzers
             id: "PSCA1001",
             title: "Undefined table.",
             messageFormat: "Table '{0}' does not exist.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static DiagnosticDescriptor UndefinedColumn { get; } = new DiagnosticDescriptor(
+            id: "PSCA1002",
+            title: "Undefined column.",
+            messageFormat: "Column '{0}' does not exist.",
             category: "Usage",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);

--- a/src/NpgsqlAnalyzers/Rules.cs
+++ b/src/NpgsqlAnalyzers/Rules.cs
@@ -11,5 +11,13 @@ namespace NpgsqlAnalyzers
             category: "Usage",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static DiagnosticDescriptor UndefinedTable { get; } = new DiagnosticDescriptor(
+            id: "PSCA1001",
+            title: "Undefined table.",
+            messageFormat: "Table '{0}' does not exist.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
     }
 }

--- a/src/NpgsqlAnalyzers/Rules.cs
+++ b/src/NpgsqlAnalyzers/Rules.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace NpgsqlAnalyzers
 {


### PR DESCRIPTION
# Overview

- Explicitly handle more SQL errors and report custom diagnostics
- Report generic diagnostic for unhandled errors
- Add regression unit tests
- Add documentation for reported diagnostics

## Diagnostics

- Use diagnostic `PSCA1000 - Bad SQL statement` as a generic diagnostic for errors which are not yet explicitly handled by the analyzer
- Implement `PSCA1001 - Undefined table`
- Implement `PSCA1002 - Undefined column`

## Tests

- Add `RegressionTests` for executing a correct query which references all tables and columns in the database; the analyzer should not report any diagnostics on this one
- Renamed tests to include the ID of the diagnostic for easier navigation
- Added tests for new diagnostics

## Documentation

- Added `docs/rules.md` with quick overview of the diagnostics