### PR TITLE
Detect query in more places and report PSCA1100

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -5,3 +5,4 @@
 | `PSCA1000` | Bad SQL statement | Warning | Reports SQL errors which are not explicitly handled by the analyzer. |
 | `PSCA1001` | Undefined table | Warning | A table referenced in the SQL statement does not exist. Provides the name of the table. |
 | `PSCA1002` | Undefined column | Warning | A column referenced in the SQL statement does not exist. Provides the name of the column. |
+| `PSCA1100` | Missing statement | Warning | An `NpgsqlCommand` does not have a SQL statement assigned to it. |

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -84,7 +84,7 @@ namespace NpgsqlAnalyzers
             // Check if object creation is NpgsqlCommand
             if (!(semanticModel.GetSymbolInfo(npgsqlCommandExpression).Symbol is IMethodSymbol methodSymbol) ||
                 methodSymbol.MethodKind != MethodKind.Constructor ||
-                !methodSymbol.ReceiverType.Name.Equals("NpgsqlCommand", StringComparison.OrdinalIgnoreCase))
+                !methodSymbol.ReceiverType.Name.Equals(nameof(NpgsqlCommand), StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -15,9 +15,6 @@ namespace NpgsqlAnalyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NpgsqlAnalyzer : DiagnosticAnalyzer
     {
-        private const string StatementMissing = nameof(StatementMissing);
-        private const string StatementNotSupported = nameof(StatementNotSupported);
-
         private readonly string _connectionString;
 
         public NpgsqlAnalyzer()

--- a/src/NpgsqlAnalyzers/Rules.cs
+++ b/src/NpgsqlAnalyzers/Rules.cs
@@ -27,5 +27,13 @@ namespace NpgsqlAnalyzers
             category: "Usage",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static DiagnosticDescriptor MissingCommand { get; } = new DiagnosticDescriptor(
+            id: "PSCA1100",
+            title: "Missing statement.",
+            messageFormat: "Provide a SQL statement via the constructor or the CommandText property.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
     }
 }

--- a/src/NpgsqlAnalyzers/SqlStatement.cs
+++ b/src/NpgsqlAnalyzers/SqlStatement.cs
@@ -10,9 +10,25 @@ namespace NpgsqlAnalyzers
             Statement = statement;
             Location = location ?? throw new ArgumentNullException(nameof(location));
             IsValid = true;
+            NotFound = false;
         }
 
+        private SqlStatement(string statement, Location location, bool isValid, bool notFound)
+        {
+            Statement = statement;
+            Location = location;
+            IsValid = isValid;
+            NotFound = notFound;
+        }
+
+        public static SqlStatement StatementNotFound { get; } = new SqlStatement(
+            statement: string.Empty,
+            location: null,
+            isValid: false,
+            notFound: true);
+
         public bool IsValid { get; }
+        public bool NotFound { get; }
         public string Statement { get; }
         public Location Location { get; }
     }

--- a/src/NpgsqlAnalyzers/SqlStatement.cs
+++ b/src/NpgsqlAnalyzers/SqlStatement.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace NpgsqlAnalyzers
+{
+    internal struct SqlStatement
+    {
+        public SqlStatement(string statement, Location location)
+        {
+            Statement = statement;
+            Location = location ?? throw new ArgumentNullException(nameof(location));
+            IsValid = true;
+        }
+
+        public bool IsValid { get; }
+        public string Statement { get; }
+        public Location Location { get; }
+    }
+}


### PR DESCRIPTION
## Overview

This update allows detecting queries passed on to `NpgsqlCommand` via the `CommandText` property. It also introduces the `PSCA1100 Missing statement` diagnostic, which reports that a `NpgsqlCommand` is not assigned a SQL statement.

The update also introduces some refactoring and the introduction of the `SqlStatement` data structure. Added more comments around the tricky places.

## SqlStatement

Represents a detected SQL statement which is going to be analyzed. Provides the following information:
- The raw SQL statement as a property, for example `SELECT * FROM users WHERE id = @id;`
- The location of where the query is defined
  - When defined as a literal in the constructor - the location of the constructor
  - When passed as a variable - the location of the string in the variable assignment

## PSCA1100 Missing statement

This diagnostic is reported when the analyzer detects that an `NpgsqlCommand` has not been assigned a SQL statement - neither through the constructor, nor the `CommandText` property.

## Refactoring

Introduced helper methods for finding variable declarations and assignments in a given collection of `SyntaxNode`s instead of doing it manually everytime.

Introduced a method which extracts a SQL statement from a given context and returns it packed conveniently as an `SqlStatement` structure. Once the statement is extracted the analysis steps can use the bundled `SqlStatement` without the need to dig in `SyntaxNode`s and contexts again.  