### PR TITLE
Use configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Diagnostic PSCA1100 - Reports if an NpgsqlCommand has not been assigned a SQL statement
+- Configuration via .npgsqlanalyzers file
+- Added docs for the new configuration file
+
+### Fixed
+- Throws an error when a connection with the database could not be established,
+instead of failing silently
+
+### Removed
+- Providing connection string via an environment variable
 
 ## [0.0.1] - 14/4/2020
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Static code analyzer which provides SQL syntax analysis in the comfort of your C
 
 ### 1. Add a configuration file to your project
 
-To be able to execute the queries against a real database, a connection string is required to said database is required. Provide the connection string to the `NpgsqlAnalyzers` through the `.npgsqlanalyzers` config file.
+To be able to execute the queries against a real database, a connection string to said database is required. Provide the connection string to the `NpgsqlAnalyzers` through the `.npgsqlanalyzers` config file.
 
 - Create a new `.npgsqlanalyzers` file
 - Add `CONNECTION_STRING=connection-string-to-your-database` in the file

--- a/README.md
+++ b/README.md
@@ -9,9 +9,21 @@ Static code analyzer which provides SQL syntax analysis in the comfort of your C
 
 ## Getting started
 
-### 1. Provide a database connection string
+### 1. Add a configuration file to your project
 
-To be able to execute the queries against a real database, a connection string is required. Provide the connection string to the `NpgsqlAnalyzers` through the `NPGSQLA_CONNECTION_STRING` **environment variable**.
+To be able to execute the queries against a real database, a connection string is required to said database is required. Provide the connection string to the `NpgsqlAnalyzers` through the `.npgsqlanalyzers` config file.
+
+- Create a new `.npgsqlanalyzers` file
+- Add `CONNECTION_STRING=connection-string-to-your-database` in the file
+- Add the following to your `.csproj`:
+
+```
+<ItemGroup>
+    <AdditionalFile Include=".npgsqlanalyzers" />
+</ItemGroup>
+```
+
+Read more about the config file [in the docs](/docs/configuration.md).
 
 ### 2. Add the analyzers to your project
 
@@ -46,6 +58,35 @@ new NpgsqlCommand(query, ...);
 
 query = "UPDATE table SET status = 'awesome'";
 new NpgsqlCommand(query, ...);
+// Detected query -> UPDATE table SET status = 'awesome'
+```
+
+- As a string literal passed to the `NpgsqlCommand.CommandText` property
+```csharp
+var command = new NpgsqlCommand();
+command.CommandText = "SELECT * FROM TABLE";
+// Detected query -> SELECT * FROM TABLE
+```
+
+- As a local variable passed to the `NpgsqlCommand.CommandText` property
+```csharp
+var query = "DELETE FROM table";
+var command = new NpgsqlCommand();
+command.CommandText = query;
+// Detected query -> DELETE FROM table
+```
+
+- As a local variable which is re-assigned and passed to the `NpgsqlCommand.CommandText` property
+```csharp
+string query = "SELECT * FROM table"
+new NpgsqlCommand(query, ...);
+// Detected query -> SELECT * FROM table
+
+// ...
+
+query = "UPDATE table SET status = 'awesome'";
+var command = new NpgsqlCommand();
+command.CommandText = query;
 // Detected query -> UPDATE table SET status = 'awesome'
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,61 @@
+# Configuring NpgsqlAnalyzers
+
+- [.npgsqlanalyzers config file](#config-file) (v0.0.2+)
+- [Environment varialbe](#environment-variable-deprecated) (v0.0.1)
+
+## Config file
+
+Since version `0.0.2` the NpgsqlAnalyzers can be configured through an `.npgsqlanalyzers` config file.
+
+### Adding the config file to the project
+
+To add the config file to your project and make it available to  NpgsqlAnalyzers
+add the folowing to your `.csproj`
+
+```
+<ItemGroup>
+    <AdditionalFile Include=".npgsqlanalyzers" />
+</ItemGroup>
+```
+
+### Format
+
+The `.npgsqlanalyzers` config file accepts configuration options as single `KEY=VALUE` pairs per line.
+
+
+- The key/value pairs are separated by `=`
+- `#` at the beginning of the line indicates a comment-line; the line will not be processed
+- The key and the value are trimmed before usage
+
+```
+# This is a comment line, indicated by "#" at the beggining.
+# It will not be processed.
+
+# This is a standard key/value pair
+KEY=VALUE
+
+# Key and value are trimmed before usage, so
+  SPACED_KEY     =      Drunk  value
+# will produce the same configuration as
+SPACED_KEY=Drunk  value
+# KEY = SPACED_KEY
+# VALUE = Drunk  value
+```
+
+
+### Configuration options
+
+The configuration file supports the following parameters
+
+| Parameter | Value | Version | Description |
+| --------- | ----- | :-----: | ----------- |
+| `CONNECTION_STRING` | Valid Npgsql connection string | 0.0.2+ | Connection string poiting to the database against which the queries will be executed in order to be verified. |
+
+## Environment variable (deprecated)
+
+> This type of configuration is deprecated and only used in version `0.0.1`. For more recent versions see [configuration via config file](#config-file).
+
+In version `0.0.1` the connection string to the database that should be used for executing queries and verifying the
+result must be set as a machine-wide environment variable.
+
+- `NPGSQLA_CONNECTION_STRING={connection-string}`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,9 @@
 # Configuring NpgsqlAnalyzers
 
 - [.npgsqlanalyzers config file](#config-file) (v0.0.2+)
+  - [Adding the config file to the project](#adding-the-config-file-to-the-project)
+  - [Format](#format)
+  - [Configuration options](#configuration-options)
 - [Environment varialbe](#environment-variable-deprecated) (v0.0.1)
 
 ## Config file
@@ -22,7 +25,6 @@ add the folowing to your `.csproj`
 
 The `.npgsqlanalyzers` config file accepts configuration options as single `KEY=VALUE` pairs per line.
 
-
 - The key/value pairs are separated by `=`
 - `#` at the beginning of the line indicates a comment-line; the line will not be processed
 - The key and the value are trimmed before usage
@@ -41,7 +43,6 @@ SPACED_KEY=Drunk  value
 # KEY = SPACED_KEY
 # VALUE = Drunk  value
 ```
-
 
 ### Configuration options
 

--- a/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/RegressionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NpgsqlAnalyzers.Tests.Utils;
 using NUnit.Framework;
 
@@ -57,7 +58,11 @@ namespace Testing
             using var database = Database.CreateDatabase();
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(database.ConnectionString));
+                new NpgsqlAnalyzer(new Configuration(
+                    new Dictionary<string, string>
+                    {
+                        ["CONNECTION_STRING"] = database.ConnectionString,
+                    })));
         }
     }
 }

--- a/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
+++ b/src/NpgsqlAnalyzers.Tests/SqlSyntaxValidationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using NpgsqlAnalyzers.Tests.Utils;
 using NUnit.Framework;
@@ -9,8 +10,18 @@ namespace NpgsqlAnalyzers.Tests
     [TestFixture]
     public class SqlSyntaxValidationTests : IDisposable
     {
-        private readonly ThrowawayDatabase _database = Database.CreateDatabase();
+        private readonly ThrowawayDatabase _database;
+        private readonly Configuration _defaultConfiguration;
         private bool _isDisposed;
+
+        public SqlSyntaxValidationTests()
+        {
+            _database = Database.CreateDatabase();
+            _defaultConfiguration = new Configuration(new Dictionary<string, string>
+            {
+                ["CONNECTION_STRING"] = _database.ConnectionString,
+            });
+        }
 
         [Test]
         public void PSCA1001_DetectedInConstructor()
@@ -33,7 +44,7 @@ namespace Testing
 
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1001",
@@ -67,7 +78,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1001",
@@ -104,7 +115,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1001",
@@ -138,7 +149,7 @@ namespace Testing
 
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -178,7 +189,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -234,7 +245,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -278,7 +289,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -313,7 +324,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -349,7 +360,7 @@ namespace Testing
 ";
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1002",
@@ -382,7 +393,7 @@ namespace Testing
 
             Diagnostics.AnalyzeSourceCode(
                 source,
-                new NpgsqlAnalyzer(_database.ConnectionString),
+                new NpgsqlAnalyzer(_defaultConfiguration),
                 new DiagnosticResult
                 {
                     Id = "PSCA1100",

--- a/src/NpgsqlAnalyzers/Configuration.cs
+++ b/src/NpgsqlAnalyzers/Configuration.cs
@@ -1,13 +1,36 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NpgsqlAnalyzers
 {
-    internal static class Configuration
+    public class Configuration
     {
-        public const string ConnectionStringEnvVar = "NPGSQLA_CONNECTION_STRING";
+        private const string ConfigAssignChar = "=";
+        private const string ConfigCommentChar = "#";
+        private const string ConfigConnectionStringKey = "CONNECTION_STRING";
 
-        public static string ConnectionString { get; } = Environment.GetEnvironmentVariable(
-            variable: ConnectionStringEnvVar,
-            target: EnvironmentVariableTarget.User);
+        public Configuration(IDictionary<string, string> args)
+        {
+            ConnectionString = args.ContainsKey(ConfigConnectionStringKey)
+                ? args[ConfigConnectionStringKey]
+                : throw new InvalidOperationException($"Missing key '{ConfigConnectionStringKey}' from configuration.");
+        }
+
+        public string ConnectionString { get; }
+
+        public static Configuration FromFile(IEnumerable<string> lines)
+        {
+            var args = lines
+                .Select((line) => line.ToString())
+                .Where((line) => !string.IsNullOrWhiteSpace(line))
+                .Where((line) => !line.StartsWith(ConfigCommentChar))
+                .Where((line) => line.Contains(ConfigAssignChar))
+                .ToDictionary(
+                    keySelector: (line) => line.Split(ConfigAssignChar[0])[0].Trim(),
+                    elementSelector: (line) => line.Split(ConfigAssignChar.ToArray(), 2)[1].Trim());
+
+            return new Configuration(args);
+        }
     }
 }

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -20,8 +20,6 @@ namespace NpgsqlAnalyzers
         private const string ConfigFileName = ".npgsqlanalyzers";
         private const string ConnectionStringKey = "CONNECTION_STRING";
 
-        private static readonly string NewLine = Environment.NewLine;
-
         private readonly string _connectionString;
 
         public NpgsqlAnalyzer()
@@ -72,6 +70,7 @@ namespace NpgsqlAnalyzers
                     }
                 }
 
+                Log($"Using connection string: {_connectionString}");
                 compilationContext.RegisterSyntaxNodeAction(
                     AnalyzeInvocationExpressionNode,
                     SyntaxKind.ObjectCreationExpression);

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -20,7 +20,7 @@ namespace NpgsqlAnalyzers
         private const string ConfigFileName = ".npgsqlanalyzers";
         private const string ConnectionStringKey = "CONNECTION_STRING";
 
-        private readonly string _connectionString;
+        private string _connectionString;
 
         public NpgsqlAnalyzer()
         {
@@ -67,6 +67,16 @@ namespace NpgsqlAnalyzers
                     foreach (var kvp in config)
                     {
                         Log($"{kvp.Key} = {kvp.Value}");
+                    }
+
+                    if (config.ContainsKey(ConnectionStringKey))
+                    {
+                        _connectionString = config[ConnectionStringKey];
+                    }
+                    else
+                    {
+                        Log("Connection string not provided in config file.");
+                        throw new InvalidOperationException("Could not find connection string in configuration file.");
                     }
                 }
 

--- a/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
+++ b/src/NpgsqlAnalyzers/NpgsqlAnalyzer.cs
@@ -62,7 +62,7 @@ namespace NpgsqlAnalyzers
                         .Where((line) => !string.IsNullOrWhiteSpace(line) && line.Contains("="))
                         .ToDictionary(
                             keySelector: (line) => line.Split('=')[0],
-                            elementSelector: (line) => line.Split('=')[1]);
+                            elementSelector: (line) => line.Split(new char[] { '=' }, 2)[1]);
                     Log("Loaded configuration properties:");
                     foreach (var kvp in config)
                     {


### PR DESCRIPTION
## Summary

This update introduces the `.npgsqlanalyzers` config file. The config file allows passing project-specific configuration details to NpgsqlAnalyzers. The first configuration received through the config file is the connection string to the target database.

## Added

- Support for .npgsqlanalyzers config file
- Receive connection string via config file
- Added docs for the new configuration file

### Fixed

- Throws an error when a connection with the database could not be established,
instead of failing silently

### Removed

- Accepting a connection string via an environment variable